### PR TITLE
Reliability score for missing values and only one rater per item

### DIFF
--- a/metrics/reliability.py
+++ b/metrics/reliability.py
@@ -1,65 +1,85 @@
 import numpy as np
 
-def irr(preds, confs = None, accs = None, cohers=None):
-	res_min = 0
-	res_max = 0
-	if confs is None:
-		confs = np.ones(preds.shape)*0.5
-	if cohers is None:
-		cohers = np.zeros(preds.shape[1])
-	if accs is None:
-		accs = np.ones(preds.shape[1])
-	for row in range(len(preds)):
-		count_min = 0
-		count_max = 0
-		r = preds[row]
-		den = 0
-		for i in range(len(r)):
-			for j in range(len(r)):
-				if i != j:
-					den += 1
-					if r[i] == r[j]:
-						count_min_temp = count_sigma(confs[row, i], confs[row, j],
-												cohers[i], cohers[j])
-						count_max_temp = count_sigma(confs[row, i], confs[row, j],
-												cohers[i], cohers[j], mode='max')
-						acc = accs[i]*accs[j]
-						acc /= (accs[i]*accs[j] + (1-accs[i])*(1-accs[j]))
-						count_min_temp *= acc
-						count_max_temp *= acc
-						count_min += count_min_temp
-						count_max += count_max_temp
-						#count += countn
-		count_min /= den
-		count_max /= den
-		res_min += count_min
-		res_max += count_max
-	return res_min/preds.shape[0], res_max/preds.shape[0]
-	
-def count_sigma(conf_i, conf_j, cohers_i, cohers_j, mode='min'):
-	count = 0
-	conf_corr_i = conf_i
-	conf_corr_j = conf_j
-	if mode == 'min':
-		conf_corr_i -= cohers_i
-		conf_corr_j -= cohers_j
-	else:
-		conf_corr_i += cohers_i
-		conf_corr_j += cohers_j
-		
-	if conf_corr_i < 0:
-		conf_corr_i = 0
-	if conf_corr_j < 0:
-		conf_corr_j = 0
-	if conf_corr_i > 1:
-		conf_corr_i = 1
-	if conf_corr_j > 1:
-		conf_corr_j = 1		
-		
-	countn = conf_corr_i*conf_corr_j
-	countd = conf_corr_i*conf_corr_j
-	countd += conf_corr_i*(1 - conf_corr_j)/2
-	countd += conf_corr_j*(1 - conf_corr_i)/2
-	countd += (1- conf_corr_i)*(1 - conf_corr_j)/4
-	count += countn/countd
-	return count
+
+def irr(preds, confs0=None, accs0=None, cohers0=None):
+    res_min = 0
+    res_max = 0
+    if confs0 is None:
+        confs0 = np.ones(preds.shape)
+    if cohers0 is None:
+        cohers0 = np.zeros(preds.shape[1])
+    if accs0 is None:
+        accs0 = np.ones(preds.shape[1])
+    for row in range(len(preds)):
+        count_min = 0
+        count_max = 0
+        r = preds[row]
+        # Drop NaN values for faster loop
+        idx = ~np.isnan(r)
+        r = r[idx]
+        accs = accs0[idx]
+        confs = confs0[row][idx]
+        cohers = cohers0[idx]
+        den = 0
+
+        # If more than one annotator, estimate agreement
+        if len(r) > 1:
+            for i in range(len(r)):
+                # Loop without repetition
+                for j in range(i + 1, len(r)):
+                    den += 1
+                    if r[i] == r[j]:
+                        count_min_temp = count_sigma(
+                            confs[i], confs[j], cohers[i], cohers[j]
+                        )
+                        count_max_temp = count_sigma(
+                            confs[i], confs[j], cohers[i], cohers[j], mode="max",
+                        )
+                        acc = accs[i] * accs[j]
+                        acc /= accs[i] * accs[j] + (1 - accs[i]) * (1 - accs[j])
+                        count_min_temp *= acc
+                        count_max_temp *= acc
+                        count_min += count_min_temp
+                        count_max += count_max_temp
+                        # count += countn
+        else:
+            # If only one annotator is present, disagreement is zero but his/her
+            # accuracy and confidence should be incorporated anyway
+            den = 1
+            count_min = float(accs) * float(confs)
+            count_max = count_min
+
+        count_min /= den
+        count_max /= den
+        res_min += count_min
+        res_max += count_max
+    return res_min / preds.shape[0], res_max / preds.shape[0]
+
+
+def count_sigma(conf_i, conf_j, cohers_i, cohers_j, mode="min"):
+    count = 0
+    conf_corr_i = conf_i
+    conf_corr_j = conf_j
+    if mode == "min":
+        conf_corr_i -= cohers_i
+        conf_corr_j -= cohers_j
+    else:
+        conf_corr_i += cohers_i
+        conf_corr_j += cohers_j
+
+    if conf_corr_i < 0:
+        conf_corr_i = 0
+    if conf_corr_j < 0:
+        conf_corr_j = 0
+    if conf_corr_i > 1:
+        conf_corr_i = 1
+    if conf_corr_j > 1:
+        conf_corr_j = 1
+
+    countn = conf_corr_i * conf_corr_j
+    countd = conf_corr_i * conf_corr_j
+    countd += conf_corr_i * (1 - conf_corr_j) / 2
+    countd += conf_corr_j * (1 - conf_corr_i) / 2
+    countd += (1 - conf_corr_i) * (1 - conf_corr_j) / 4
+    count += countn / countd
+    return count


### PR DESCRIPTION
Include the case where not all annotators give an opinion for a given item and the case with only one opinion per item (no disagreement). Improved loop for faster computation with combinations without repetitions (x100 faster).

Consider a dataset with missing values like this:

record1:    1, null, null,    2, null;
record2: null,    1, null,    3,     1;
record3: null,    1, null, null, null;
recordN: ...

where columns are 5 raters. Note that record3 has only one rater's opinion.

I'm not an expert of this field but I would really like to use this metric with the usual alpha. @AndreaCampagner it would be really nice if you could check if this implementation do not hurt the initial idea of the metric. I've checked the output based on the testing "data" between the original and this version and they give the same result, but I don't now if it is still correct for missing values.